### PR TITLE
Uses int64_t for trial counts

### DIFF
--- a/plugin/flat_histogram/src/flat_histogram.cpp
+++ b/plugin/flat_histogram/src/flat_histogram.cpp
@@ -34,13 +34,21 @@ FlatHistogram::FlatHistogram(std::shared_ptr<Macrostate> macrostate,
   class_name_ = "FlatHistogram";
   init_(macrostate, bias);
 }
-FlatHistogram::FlatHistogram(argtype * args) : Criteria(args) {
+
+FlatHistogram::FlatHistogram(argtype * args)
+ : Criteria(
+     [&]() {
+       ASSERT(!used("cycles_to_complete", *args),
+         "FlatHistogram does not use the argument cycles_to_complete");
+       return args;
+     }()
+   )
+{
   class_name_ = "FlatHistogram";
-  ASSERT(!used("cycles_to_complete", *args),
-    "FlatHistogram does not use the argument cycles_to_complete");
   init_(MacrostateEnergy().factory(str("Macrostate", args), args),
         MakeWangLandau({{"min_flatness", "1"}})->factory(str("Bias", args), args));
 }
+
 FlatHistogram::FlatHistogram(argtype args) : FlatHistogram(&args) {
   feasst_check_all_used(args);
 }

--- a/plugin/monte_carlo/include/monte_carlo.h
+++ b/plugin/monte_carlo/include/monte_carlo.h
@@ -7,6 +7,7 @@
 #include <string>
 #include <memory>
 #include <map>
+#include <cstdint>
 
 namespace feasst {
 
@@ -266,7 +267,7 @@ class MonteCarlo {
   virtual void reset_trial_stats();
 
   /// Run a number of trials.
-  virtual void run_num_trials(int num_trials);
+  virtual void run_num_trials(int64_t num_trials);
 
   /// Run until a number of particles is reached.
   virtual void run_until_num_particles(const int num_particles,

--- a/plugin/monte_carlo/include/run.h
+++ b/plugin/monte_carlo/include/run.h
@@ -5,6 +5,7 @@
 #include <memory>
 #include <string>
 #include <vector>
+#include <cstdint>
 #include "monte_carlo/include/action.h"
 
 namespace feasst {
@@ -52,7 +53,7 @@ class Run : public Action {
 
   //@}
  private:
-  int num_trials_;
+  int64_t num_trials_;
   int until_num_particles_;
   int configuration_index_;
   std::string config_;

--- a/plugin/monte_carlo/src/monte_carlo.cpp
+++ b/plugin/monte_carlo/src/monte_carlo.cpp
@@ -923,7 +923,7 @@ void MonteCarlo::write_to_file() {
   modify_factory_->write_to_file(this);
 }
 
-void MonteCarlo::run_num_trials(int num_trials) {
+void MonteCarlo::run_num_trials(int64_t num_trials) {
   while (num_trials > 0) {
     attempt(1);
     --num_trials;

--- a/plugin/monte_carlo/src/run.cpp
+++ b/plugin/monte_carlo/src/run.cpp
@@ -11,7 +11,7 @@
 namespace feasst {
 
 Run::Run(argtype * args) {
-  num_trials_ = integer("num_trials", args, -1);
+  num_trials_ = integer64("num_trials", args, -1);
   until_num_particles_ = integer("until_num_particles", args, -1);
   if (used("configuration_index", *args)) {
     WARN("Deprecated Run::configuration_index->config (see Configuration::name)");

--- a/plugin/prefetch/include/prefetch.h
+++ b/plugin/prefetch/include/prefetch.h
@@ -5,6 +5,7 @@
 #include <string>
 #include <vector>
 #include <memory>
+#include <cstdint>
 #include "monte_carlo/include/monte_carlo.h"
 
 namespace feasst {
@@ -109,7 +110,7 @@ class Prefetch : public MonteCarlo {
   void run(std::shared_ptr<Action> action) override;
 
   /// Run a number of trials.
-  void run_num_trials(int num_trials) override;
+  void run_num_trials(int64_t num_trials) override;
   void run_until_num_particles(const int num_particles,
                                const std::string& particle_type,
                                const int configuration_index) override;

--- a/plugin/prefetch/src/prefetch.cpp
+++ b/plugin/prefetch/src/prefetch.cpp
@@ -528,7 +528,7 @@ void Prefetch::run(std::shared_ptr<Action> action) {
   }
 }
 
-void Prefetch::run_num_trials(int num_trials) {
+void Prefetch::run_num_trials(int64_t num_trials) {
   if (num_trials < 0) {
     return;
   }

--- a/plugin/utils/include/arguments.h
+++ b/plugin/utils/include/arguments.h
@@ -6,6 +6,7 @@
 #include <vector>
 #include <map>
 #include <string>
+#include <cstdint>
 
 namespace feasst {
 
@@ -61,6 +62,13 @@ int integer(const std::string& key, argtype * args);
 /// Same as above, but with a default value should key not be in args.
 int integer(const std::string& key, argtype * args,
   const int dflt);
+
+/// Read an argument and remove it from args, then return as 64-bit integer.
+int64_t integer64(const std::string& key, argtype * args);
+
+/// Same as above, but with a default value should key not be in args.
+int64_t integer64(const std::string& key, argtype * args,
+  const int64_t dflt);
 
 /// Read an argument and remove it from args, then return as a boolean.
 bool boolean(const std::string& key, argtype * args);

--- a/plugin/utils/include/io.h
+++ b/plugin/utils/include/io.h
@@ -7,6 +7,7 @@
 #include <vector>
 #include <deque>
 #include <map>
+#include <cstdint>
 #include "utils/include/max_precision.h"
 #include "utils/include/definitions.h"
 
@@ -80,6 +81,11 @@ bool replace(const std::string& from, const std::string& to, std::string * str);
 
 /// Convert a string to an integer.
 int str_to_int(const std::string& str,
+  /// Return a FATAL error if impossible. Otherwise, return -1.
+  const bool fatal = true);
+
+/// Convert a string to a 64-bit integer.
+int64_t str_to_int64(const std::string& str,
   /// Return a FATAL error if impossible. Otherwise, return -1.
   const bool fatal = true);
 

--- a/plugin/utils/include/timer_rdtsc.h
+++ b/plugin/utils/include/timer_rdtsc.h
@@ -4,6 +4,7 @@
 
 #include <string>
 #include <vector>
+#include <cstdint>
 
 namespace feasst {
 

--- a/plugin/utils/src/arguments.cpp
+++ b/plugin/utils/src/arguments.cpp
@@ -79,6 +79,22 @@ int integer(const std::string& key, argtype * args,
   }
 }
 
+int64_t integer64(const std::string& key, argtype * args) {
+  return str_to_int64(str(key, args));
+}
+
+int64_t integer64(const std::string& key, argtype * args,
+    const int64_t dflt) {
+  auto pair = args->find(key);
+  if (pair != args->end()) {
+    const std::string return_str = pair->second;
+    args->erase(pair);
+    return str_to_int64(return_str);
+  } else {
+    return dflt;
+  }
+}
+
 bool boolean(const std::string& key, argtype * args) {
   return str_to_bool(str(key, args));
 }

--- a/plugin/utils/src/io.cpp
+++ b/plugin/utils/src/io.cpp
@@ -1,6 +1,7 @@
 #include <cmath>
 #include <iterator>
 #include <algorithm>
+#include <limits>
 #include "utils/include/io.h"
 #include "utils/include/debug.h"
 #include "utils/include/definitions.h"
@@ -72,18 +73,31 @@ bool is_found_in(const std::string& str, const std::string& substr) {
 }
 
 int str_to_int(const std::string& str, const bool fatal) {
+  const int64_t val64 = str_to_int64(str, fatal);
+  if (val64 > std::numeric_limits<int>::max() ||
+      val64 < std::numeric_limits<int>::min()) {
+    if (fatal) {
+      FATAL(str << " was expected to be within int range.");
+    } else {
+      return -1;
+    }
+  }
+  return static_cast<int>(val64);
+}
+
+int64_t str_to_int64(const std::string& str, const bool fatal) {
   std::stringstream errmsg;
-  int intVal = -1;
+  int64_t intVal = -1;
   errmsg << str << " was " << "expected to be an integer.";
   if (str.find('e') != std::string::npos) {
     const double dble = str_to_double(str);
-    const int intt = static_cast<int>(dble);
+    const int64_t intt = static_cast<int64_t>(dble);
     ASSERT(std::abs(dble - static_cast<double>(intt)) < 1e-14,
       errmsg.str());
     return intt;
   }
   try {
-    intVal = stoi(str);
+    intVal = std::stoll(str);
   } catch (...) {
     if (fatal) {
       FATAL(errmsg.str());
@@ -91,7 +105,7 @@ int str_to_int(const std::string& str, const bool fatal) {
       return -1;
     }
   }
-  const double dble = stod(str);
+  const double dble = std::stod(str);
   ASSERT(std::abs(dble - static_cast<double>(intVal)) < 1e-14,
     errmsg.str());
   return intVal;


### PR DESCRIPTION
Increases the maximum number of trials that can be run by using a 64-bit integer to store the trial count.

This prevents integer overflow issues when running simulations for more than 2.1e9 steps.

Fixes bug where assertion for using `cycles_to_complete` with `FlatHistogram` was never executed.